### PR TITLE
(tweak/vrp) solved `memory leak` provoked by `users_by_cid`

### DIFF
--- a/vrp/vRP.lua
+++ b/vrp/vRP.lua
@@ -288,6 +288,7 @@ function vRP:disconnectUser(source, reason)
     -- unreference
     self.users[user.id] = nil
     self.users_by_source[user.source] = nil
+	if user.cid then self.users_by_cid[user.cid] = nil end
     self:log(user.name.." ("..user.endpoint..") disconnected (user_id = "..user.id..")")
   end
 end


### PR DESCRIPTION
the user data should not remain in `users_by_cid` when the player actually quits the game/disconnects; this should solve a minor `memory leak` problem or whoever use `vRP.users_by_cid` with a stored `cid`;